### PR TITLE
StdのIteratorの実装の変更に対応

### DIFF
--- a/fixproj.toml
+++ b/fixproj.toml
@@ -35,11 +35,11 @@ git = { url = "https://github.com/pt9999/fixlang-minilib-common.git" }
 
 [[dependencies]]
 name = "hashmap"
-version = "*"
+version = "1.1.0"
 git = { url = "https://github.com/tttmmmyyyy/fixlang-hashmap.git" }
 
 # for test_util_array.fix
 [[dependencies]]
 name = "random"
-version = "1.0.0"
+version = "1.1.0"
 git = { url = "https://github.com/tttmmmyyyy/fixlang-random.git" }

--- a/lib/collection/deque.fix
+++ b/lib/collection/deque.fix
@@ -81,10 +81,12 @@ namespace Deque {
     );
 
     // Returns an iterator of elements.
-    to_iter: Deque a -> Iterator a;
+    to_iter: Deque a -> DequeIterator a;
     to_iter = |q| (
         q.@front.to_iter.reverse.append(q.@back.to_iter)
     );
+
+    type DequeIterator a = AppendIterator (ReverseIterator (ArrayIterator a) a) (ArrayIterator a);
 
     // Reverses an array.
     _reverse_array: Array a -> Array a;

--- a/lib/collection/ordered_map.fix
+++ b/lib/collection/ordered_map.fix
@@ -61,7 +61,7 @@ namespace OrderedMap {
 
     // Convert an OrderedMap into an iterator. The order of the elements is the same as 
     // when they were inserted into the map.
-    to_iter : OrderedMap k v -> Iterator (k, v);
+    to_iter : OrderedMap k v -> OrderedMapIterator k v;
     to_iter = |self| (
         let array = self.@map.to_iter.to_array;
         let array = array.sort_by(|(e1, e2)|
@@ -71,6 +71,8 @@ namespace OrderedMap {
         );
         array.to_iter.map(|(k, (s,v))| (k, v))
     );
+
+    type OrderedMapIterator k v = Std::Iterator::MapIterator (Std::Iterator::ArrayIterator (k, (Std::I64, v))) (k, (Std::I64, v)) (k, v);
 }
 
 impl [k: HashKey, v: Eq] OrderedMap k v: Eq
@@ -82,7 +84,7 @@ impl [k: HashKey, v: Eq] OrderedMap k v: Eq
         let every = |f, iter| (
             iter.loop_iter(
                 true,
-                |_, x|
+                |x, _|
                 if !f(x) {
                     break $ false
                 };
@@ -98,7 +100,7 @@ impl [k: HashKey, v: Eq] OrderedMap k v: Eq
 impl [k: HashKey, k: ToString, v: ToString] OrderedMap k v : ToString {
     to_string = |om| (
         "{" +
-        om.to_iter.map(|(k,v)| k.to_string + ":" + v.to_string).join(",")
+        om.to_iter.Iterator::map(|(k,v)| k.to_string + ":" + v.to_string).join(",")
         + "}"
     );
 }

--- a/lib/collection/rbtree.fix
+++ b/lib/collection/rbtree.fix
@@ -186,9 +186,9 @@ namespace RBNode {
     // such that `!elem.lt_begin && elem.lt_end` is true.
     // NOTE: `lt_begin` and `lt_end` must meet following condition:
     // for all `x`, `x.lt_begin` is true then `x.lt_end` must be true.
-    find_range: (a -> Bool) -> (a -> Bool) -> RBNode a -> Iterator a;
+    find_range: (a -> Bool) -> (a -> Bool) -> RBNode a -> DynIterator a;
     find_range = |lt_begin, lt_end, node| (
-        if node.is_empty { Iterator::empty };
+        if node.is_empty { DynIterator::empty };
         let next = |_| (
             let (left, elem, right) = node.get_triplet;
             if elem.lt_begin {         // elem < begin
@@ -196,21 +196,21 @@ namespace RBNode {
             } else if elem.lt_end {    // begin <= elem && elem < end
                 left.find_range(lt_begin, lt_end)
                 ._fast_append(right.find_range(lt_begin, lt_end)
-                        .push_front(elem))
+                        .push_front(elem).to_dyn)
             } else {                    // end <= elem
                 left.find_range(lt_begin, lt_end)
             }
         ).advance;
-        Iterator { next: next }
+        DynIterator { next: next }
     );
 
     // `node.find_range(lt_begin, lt_end)` finds all elements `elem`
     // such that `!elem.lt_begin && elem.lt_end` is true, in descending order.
     // NOTE: `lt_begin` and `lt_end` must meet following condition:
     // for all `x`, `x.lt_begin` is true then `x.lt_end` must be true.
-    find_range_descending: (a -> Bool) -> (a -> Bool) -> RBNode a -> Iterator a;
+    find_range_descending: (a -> Bool) -> (a -> Bool) -> RBNode a -> DynIterator a;
     find_range_descending = |lt_begin, lt_end, node| (
-        if node.is_empty { Iterator::empty };
+        if node.is_empty { DynIterator::empty };
         let next = |_| (
             let (left, elem, right) = node.get_triplet;
             if elem.lt_begin {         // elem < begin
@@ -218,24 +218,24 @@ namespace RBNode {
             } else if elem.lt_end {    // begin <= elem && elem < end
                 right.find_range_descending(lt_begin, lt_end)
                 ._fast_append(left.find_range_descending(lt_begin, lt_end)
-                        .push_front(elem))
+                        .push_front(elem).to_dyn)
             } else {                    // end <= elem
                 left.find_range_descending(lt_begin, lt_end)
             }
         ).advance;
-        Iterator { next: next }
+        DynIterator { next: next }
     );
 
     // Same as `Iterator::append` but a little fast.
-    _fast_append : Iterator a -> Iterator a -> Iterator a;
+    _fast_append : DynIterator a -> DynIterator a -> DynIterator a;
     _fast_append = |rhs, lhs| (
         let next = |_| (
             let opt = lhs.advance;
             if opt.is_none { rhs.advance };
-            let (e, lhs) = opt.as_some;
-            some $ (e, lhs._fast_append(rhs))
+            let (lhs, e) = opt.as_some;
+            some $ (lhs._fast_append(rhs), e)
         );
-        Iterator { next : next }
+        DynIterator { next : next }
     );
 
     // Gets the first element (that is, the smallest element) of the tree.
@@ -694,22 +694,22 @@ namespace RBNode {
         node._to_array_inner([])
     );
 
-    to_iter: [a: RBNodeElem] RBNode a -> Iterator a;
+    to_iter: [a: RBNodeElem] RBNode a -> DynIterator a;
     to_iter = |node| (
-        if node.is_empty { Iterator::empty };
+        if node.is_empty { DynIterator::empty };
         let (left, elem, right) = node.get_triplet;
-        left.to_iter._fast_append(right.to_iter.push_front(elem))
+        left.to_iter._fast_append(right.to_iter.push_front(elem).to_dyn)
     );
 
-    from_iter_lt: [a: RBNodeElem] (a -> a -> Bool) -> Iterator a -> RBNode a;
+    from_iter_lt: [a: RBNodeElem, it: Iterator, Item it = a] (a -> a -> Bool) -> it -> RBNode a;
     from_iter_lt = |less_than, iter| (
         iter.fold(
-            empty(), |node, x|
+            empty(), |x, node|
             node.insert_lt(x, less_than)
         )
     );
 
-    from_iter: [a: LessThan, a: RBNodeElem] Iterator a -> RBNode a;
+    from_iter: [a: LessThan, a: RBNodeElem, it: Iterator, Item it = a] it -> RBNode a;
     from_iter = |iter| (
         iter.from_iter_lt(_less_than)
     );

--- a/lib/collection/tree_map.fix
+++ b/lib/collection/tree_map.fix
@@ -100,7 +100,7 @@ namespace TreeMap {
     );
 
     // Returns an iterator of keys in ascending order.
-    keys: [k: TreeMapKey, v: TreeMapValue] TreeMap k v -> Iterator k;
+    keys: [k: TreeMapKey, v: TreeMapValue] TreeMap k v -> DynIterator k;
     keys = |tm| (
         tm.to_iter.map(|e| e.@0)
     );
@@ -118,7 +118,7 @@ namespace TreeMap {
     // `tm.find_range(begin, end)` finds all entries `(k,v)`
     // where `!less_than(k, begin) && less_than(k, end)` is true.
     // In default `LessThan` ordering, that condition is same as `begin <= k && k < end`.
-    find_range: [k: TreeMapKey, v: TreeMapValue] k -> k -> TreeMap k v -> Iterator (k, v);
+    find_range: [k: TreeMapKey, v: TreeMapValue] k -> k -> TreeMap k v -> DynIterator (k, v);
     find_range = |begin, end, tm| (
         let less_than = tm.@key_less_than;
         let lt_begin = |(ent_k,_)| less_than(ent_k, begin);
@@ -130,7 +130,7 @@ namespace TreeMap {
     // where `!lt_begin((k, v)) && lt_end((k, v))` is true.
     // NOTE: `lt_begin` and `lt_end` must meet following condition:
     // for all `(k,v)`, `lt_begin((k,v))` is true then `lt_end((k,v))` must be true.
-    find_raw_range: [k: TreeMapKey, v: TreeMapValue] ((k,v) -> Bool) -> ((k,v) -> Bool) -> TreeMap k v -> Iterator (k, v);
+    find_raw_range: [k: TreeMapKey, v: TreeMapValue] ((k,v) -> Bool) -> ((k,v) -> Bool) -> TreeMap k v -> DynIterator (k, v);
     find_raw_range = |lt_begin, lt_end, tm| (
         tm.@root.find_range(lt_begin, lt_end)
     );
@@ -142,13 +142,13 @@ namespace TreeMap {
     );
 
     // Converts a TreeMap into an iterator of key-value pairs in ascending order of keys.
-    to_iter: [k: TreeMapKey, v: TreeMapValue] TreeMap k v -> Iterator (k, v);
+    to_iter: [k: TreeMapKey, v: TreeMapValue] TreeMap k v -> DynIterator (k, v);
     to_iter = |tm| (
         tm.@root.to_iter
     );
 
     // Converts an iterator of key-value pairs into a TreeMap using specified ordering.
-    from_iter_lt: [k: TreeMapKey, v: TreeMapValue] (k -> k -> Bool) -> Iterator (k, v) -> TreeMap k v;
+    from_iter_lt: [k: TreeMapKey, v: TreeMapValue, it: Iterator, Item it = (k, v)] (k -> k -> Bool) -> it -> TreeMap k v;
     from_iter_lt = |key_less_than, iter| (
         let tm = TreeMap::make_lt(key_less_than);
         let root = RBNode::from_iter_lt(tm.@entry_less_than, iter);
@@ -156,7 +156,7 @@ namespace TreeMap {
     );
 
     // Converts an iterator of key-value pairs into a TreeMap using default `LessThan` ordering.
-    from_iter: [k: LessThan, k: TreeMapKey, v: TreeMapValue] Iterator (k, v) -> TreeMap k v;
+    from_iter: [k: LessThan, k: TreeMapKey, v: TreeMapValue, it: Iterator, Item it = (k, v)] it -> TreeMap k v;
     from_iter = |iter| (
         TreeMap::from_iter_lt(RBNode::_less_than, iter)
     );
@@ -164,6 +164,6 @@ namespace TreeMap {
 
 impl [k: TreeMapKey, v: TreeMapValue] TreeMap k v: ToString {
     to_string = |tm| (
-        "TreeMap{" + tm.to_iter.map(to_string).join(",") + "}"
+        "TreeMap{" + tm.to_iter.Iterator::map(to_string).join(",") + "}"
     );
 }

--- a/lib/collection/tree_set.fix
+++ b/lib/collection/tree_set.fix
@@ -73,7 +73,7 @@ namespace TreeSet {
     // `ts.find_range(begin, end)` finds all elements `x`
     // where `!less_than(x, begin) && less_than(x, end)` is true.
     // In default `LessThan` ordering, that condition is same as `begin <= x && x < end`.
-    find_range: [a: TreeSetElem] a -> a -> TreeSet a -> Iterator a;
+    find_range: [a: TreeSetElem] a -> a -> TreeSet a -> DynIterator a;
     find_range = |begin, end, ts| (
         let less_than = ts.@less_than;
         let lt_begin = |x| less_than(x, begin);
@@ -85,7 +85,7 @@ namespace TreeSet {
     // where `!lt_begin(x) && lt_end(x)` is true.
     // NOTE: `lt_begin` and `lt_end` must meet following condition:
     // for all `x`, `x.lt_begin` is true then `x.lt_end` must be true.
-    find_raw_range: [a: TreeSetElem] (a -> Bool) -> (a -> Bool) -> TreeSet a -> Iterator a;
+    find_raw_range: [a: TreeSetElem] (a -> Bool) -> (a -> Bool) -> TreeSet a -> DynIterator a;
     find_raw_range = |lt_begin, lt_end, ts| (
         ts.@root.find_range(lt_begin, lt_end)
     );
@@ -97,13 +97,13 @@ namespace TreeSet {
     );
 
     // Converts a TreeSet into an iterator in sorted order.
-    to_iter: [a: TreeSetElem] TreeSet a -> Iterator a;
+    to_iter: [a: TreeSetElem] TreeSet a -> DynIterator a;
     to_iter = |ts| (
         ts.@root.to_iter
     );
 
     // Converts an iterator into a TreeSet using specified ordering.
-    from_iter_lt: [a: TreeSetElem] (a -> a -> Bool) -> Iterator a -> TreeSet a;
+    from_iter_lt: [a: TreeSetElem, it: Iterator, Item it = a] (a -> a -> Bool) -> it -> TreeSet a;
     from_iter_lt = |less_than, iter| (
         TreeSet {
             root: RBNode::from_iter_lt(less_than, iter),
@@ -112,7 +112,7 @@ namespace TreeSet {
     );
 
     // Converts an iterator into a TreeSet using default `LessThan` ordering.
-    from_iter: [a: LessThan, a: TreeSetElem] Iterator a -> TreeSet a;
+    from_iter: [a: LessThan, a: TreeSetElem, it: Iterator, Item it = a] it -> TreeSet a;
     from_iter = |iter| (
         TreeSet::from_iter_lt(RBNode::_less_than, iter)
     );
@@ -121,7 +121,7 @@ namespace TreeSet {
     intersect: [a : TreeSetElem] TreeSet a -> TreeSet a -> TreeSet a;
     intersect = |ts1, ts2| (
         ts1.to_iter.fold(
-            ts1, |ts1, x|
+            ts1, |x, ts1|
             if ts2.contains(x) {
                 ts1
             } else {
@@ -134,7 +134,7 @@ namespace TreeSet {
     merge: [a : TreeSetElem] TreeSet a -> TreeSet a -> TreeSet a;
     merge = |ts1, ts2| (
         ts2.to_iter.fold(
-            ts1, |ts1, x|
+            ts1, |x, ts1|
             ts1.insert(x)
         )
     );
@@ -143,6 +143,6 @@ namespace TreeSet {
 // Converts a TreeSet into a String.
 impl [a: TreeSetElem] TreeSet a: ToString {
     to_string = |ts| (
-        "TreeSet{" + ts.to_iter.map(to_string).join(",") + "}"
+        "TreeSet{" + ts.to_iter.Iterator::map(to_string).join(",") + "}"
     );
 }

--- a/tests/collection/ordered_map_test.fix
+++ b/tests/collection/ordered_map_test.fix
@@ -32,7 +32,7 @@ test_erase = (
     let iter = Iterator::count_up(0).take(n);
     let om: OrderedMap I64 String = iter.fold(
         OrderedMap::empty(0),
-        |m, i| m.insert(i, i.to_string));
+        |i, m| m.insert(i, i.to_string));
     let om = om.erase(erase_key);
     let actual = om.to_iter.to_array;
     let expected = iter.filter(|i| i != erase_key).map(|i| (i, i.to_string)).to_array;
@@ -83,7 +83,7 @@ test_to_iter = (
     let iter = Iterator::count_up(0).take(p).map(|i| (i * 5) % p);
     let om: OrderedMap I64 String = iter.fold(
         OrderedMap::empty(0),
-        |m, i| m.insert(i, i.to_string));
+        |i, m| m.insert(i, i.to_string));
     let actual = om.to_iter.to_array;
     let expected = iter.map(|i| (i, i.to_string)).to_array;
     let _ = *(assert_equal("should equal array", expected, actual));
@@ -97,10 +97,10 @@ test_eq = (
     let iter = Iterator::count_up(0).take(p);
     let om1: OrderedMap I64 String = iter.map(|i| (i * 5) % p).fold(
         OrderedMap::empty(0),
-        |m, i| m.insert(i, i.to_string));
+        |i, m| m.insert(i, i.to_string));
     let om2: OrderedMap I64 String = iter.map(|i| (i * 3) % p).fold(
         OrderedMap::empty(0),
-        |m, i| m.insert(i, i.to_string));
+        |i, m| m.insert(i, i.to_string));
     let _ = *(assert_equal("should be equal even if different order", om1, om2));
     let om1 = om1.insert(1, "1");
     let _ = *(assert_equal("should be equal even if same key-value is insered", om1, om2));

--- a/tests/collection/rbtree_test.fix
+++ b/tests/collection/rbtree_test.fix
@@ -35,7 +35,7 @@ test_insert_remove_ok = |(n, insert_reorder, remove_reorder)| (
     // test remove
     let shuffled = array.reorder(remove_reorder);
     let node = *shuffled.to_iter.zip(Iterator::count_up(0)).fold_m(
-        node, |node, (i, idx)|
+        node, |(i, idx), node|
         eval _debug_eprintln_lazy(|_| "removing: idx="+idx.to_string+" i="+i.to_string + " node="+node.to_string);
         eval _debug_eprintln_lazy(|_| "node.level=" + node.level.to_string);
         let node = node.remove(i);
@@ -71,7 +71,7 @@ test_get_first_last = (
         (40, shuffle(234)),
         (50, shuffle(345))
     ].to_iter.fold_m(
-        (), |_, (n, insert_reorder)|
+        (), |(n, insert_reorder), _|
         let array = Iterator::range(0, n).to_array;
         let node: RBNode I64 = array.reorder(insert_reorder).to_iter.from_iter;
         let _ = *assert_equal("get_first: n="+n.to_string, 
@@ -103,7 +103,7 @@ test_find_range_ok = |insert_reorder| (
         ([], (n, n+1))
     ];
     test_patterns.to_iter.fold_m(
-        (), |_, (expected, (begin, end))|
+        (), |(expected, (begin, end)), _|
         let actual = node.find_range(|x| x < begin, |x| x < end).to_array;
         let _ = *assert_equal("find_range", expected, actual);
         let expected = expected.to_iter.reverse.to_array;

--- a/tests/collection/tree_map_test.fix
+++ b/tests/collection/tree_map_test.fix
@@ -35,7 +35,7 @@ test_insert_erase_ok = |(n, insert_reorder, erase_reorder)| (
     let keys_shuffled = keys_sorted.reorder(insert_reorder);
     let map: TreeMap I64 String = TreeMap::make();
     let map = keys_shuffled.to_iter.fold(
-        map, |map, k|
+        map, |k, map|
         map.insert(k, "value-1-" + k.to_string )
     );
 
@@ -45,7 +45,7 @@ test_insert_erase_ok = |(n, insert_reorder, erase_reorder)| (
 
     // assert that keys exist and values are correct
     let _ = *keys_sorted.to_iter.fold_m(
-        (), |_, k|
+        (), |k, _|
         let _ = *assert_equal("map.contains_key", true, map.contains_key(k));
         let v = map.find(k);
         assert_equal("map.find", some("value-1-" + k.to_string), v)
@@ -53,7 +53,7 @@ test_insert_erase_ok = |(n, insert_reorder, erase_reorder)| (
 
     // change values
     let map = keys_shuffled.to_iter.fold(
-        map, |map, k|
+        map, |k, map|
         map.insert(k, "value-2-" + k.to_string )
     );
 
@@ -63,7 +63,7 @@ test_insert_erase_ok = |(n, insert_reorder, erase_reorder)| (
 
     // assert that keys exist and values are correct
     let _ = *keys_sorted.to_iter.fold_m(
-        (), |_, k|
+        (), |k, _|
         let _ = *assert_equal("map.contains_key", true, map.contains_key(k));
         let v = map.find(k);
         assert_equal("map.find", some("value-2-" + k.to_string), v)
@@ -72,7 +72,7 @@ test_insert_erase_ok = |(n, insert_reorder, erase_reorder)| (
     // erase keys
     let keys_shuffled = keys_sorted.reorder(erase_reorder);
     let map = keys_shuffled.to_iter.fold(
-        map, |map, i|
+        map, |i, map|
         map.erase(i)
     );
     let keys_current = map.keys.to_array;
@@ -114,7 +114,7 @@ test_find_range = (
     let keys_sorted = Iterator::range(0, 30).to_array;
     let keys_shuffled = keys_sorted.reorder(shuffle(345));
     let map = keys_shuffled.to_iter.fold(
-        TreeMap::make(), |map, k|
+        TreeMap::make(), |k, map|
         map.insert(k, k*10)
     );
     let test_find_range_ok = |begin, end, expected| (

--- a/tests/collection/tree_set_test.fix
+++ b/tests/collection/tree_set_test.fix
@@ -35,7 +35,7 @@ test_insert_erase_ok = |(n, insert_reorder, erase_reorder)| (
     let keys_shuffled = keys_sorted.reorder(insert_reorder);
     let set: TreeSet I64 = TreeSet::make();
     let set = keys_shuffled.to_iter.fold(
-        set, |set, k|
+        set, |k, set|
         set.insert(k)
     );
 
@@ -45,14 +45,14 @@ test_insert_erase_ok = |(n, insert_reorder, erase_reorder)| (
 
     // assert that keys exist
     let _ = *keys_sorted.to_iter.fold_m(
-        (), |_, k|
+        (), |k, _|
         assert_equal("set.contains", true, set.contains(k))
     );
 
     // erase keys
     let keys_shuffled = keys_sorted.reorder(erase_reorder);
     let set = keys_shuffled.to_iter.fold(
-        set, |set, i|
+        set, |i, set|
         set.erase(i)
     );
     let keys_current = set.to_iter.to_array;
@@ -78,7 +78,7 @@ test_find_range = (
     let keys_sorted = Iterator::range(0, 30).to_array;
     let keys_shuffled = keys_sorted.reorder(shuffle(345));
     let set = keys_shuffled.to_iter.fold(
-        TreeSet::make(), |set, x|
+        TreeSet::make(), |x, set|
         set.insert(x)
     );
     let test_find_range_ok = |begin, end, expected| (
@@ -141,8 +141,8 @@ test_tuple2 = (
         (user1 < user2) || (user1 == user2 && book1 < book2)
     );
     let iter = do {
-        let user = *Iterator::range(0,10).map(|i| "user" + i.to_string);
-        let book = *Iterator::range(0,10).map(|i| "book" + i.to_string);
+        let user = *Iterator::range(0,10).map(|i| "user" + i.to_string).to_dyn;
+        let book = *Iterator::range(0,10).map(|i| "book" + i.to_string).to_dyn;
         pure $ (user,book)
     };
     let iter = iter.to_array.reorder(shuffle(345)).to_iter;


### PR DESCRIPTION
"(1) StdのIteratorの実装の変更に対応しました。

(2) コレクションを実装したとき、to_iterの実装方法として2通りの選択肢があります。一つはDynIteratorを返すことで、もう一つは専用のイテレータ型を用意することです。
前者は型が簡潔になるのがメリットで、後者はそのイテレータのイテレーションが高速になることがメリットです。
なお、一旦前者で実装したあと、（language serverの機能で）to_dynの型を調べることで、後者の実装に切り替えるために必要になる（複雑な）イテレータの型が調べられる、というTipsがあります。

TreeMap、TreeSetでは前者を、DequeとOrderedMapでは後者を選択しました。
TreeMapとTreeSetはイテレータが再帰的に作成されるため、to_dynを使うこと容易には避けられないのではないかと考えています。"